### PR TITLE
Adds support for reassignments within response transforms.

### DIFF
--- a/lib/apisauce.js
+++ b/lib/apisauce.js
@@ -153,13 +153,12 @@ export const create = (config) => {
     let data = response && response.data || null
 
     // give an opportunity for anything to the response transforms to change stuff along the way
+    let transformedResponse = { duration, problem, ok, status, headers, config, data }
     if (responseTransforms.length > 0) {
-      R.forEach(transform => {
-        transform({ duration, problem, ok, status, headers, config, data })
-      }, responseTransforms)
+      R.forEach(transform => transform(transformedResponse), responseTransforms)
     }
 
-    return { duration, problem, ok, status, headers, config, data }
+    return transformedResponse
   }
 
   /**

--- a/test/responseTransformTests.js
+++ b/test/responseTransformTests.js
@@ -39,3 +39,19 @@ test('alters the response', (t) => {
     t.deepEqual(response.data.a, 'hi')
   })
 })
+
+test('swap out data on response', t => {
+  const x = create({ baseURL: `http://localhost:${port}` })
+  let count = 0
+  x.addResponseTransform(response => {
+    count++
+    response.status = 222
+    response.data = { a: R.reverse(response.data.a.b) }
+  })
+  // t.is(count, 0)
+  return x.get('/number/201').then(response => {
+    t.is(response.status, 222)
+    t.is(count, 1)
+    t.deepEqual(response.data.a, [3, 2, 1])
+  })
+})


### PR DESCRIPTION
In a response transform, it should be totally legit to swap things out and reassign them.

That's the whole point.  You're transforming it!

```js
myApi.addResponseTransform(response => {
  response.data = { ... } // camelize keys is a great example
}) 
```

Fixes #42.

