### PR TITLE
Added babel-plugin-ramda

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,8 @@
   "presets": [ "es2015" ],
   "plugins": [
     "fast-async",
-    "transform-object-rest-spread"
+    "transform-object-rest-spread",
+    "ramda"
   ],
   "ignore": "test/*",
   "env": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-cli": "^6.24.0",
     "babel-core": "^6.24.0",
     "babel-eslint": "^7.1.1",
+    "babel-plugin-ramda": "^1.2.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-es2015-rollup": "^3.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,19 @@ import babel from 'rollup-plugin-babel'
 import uglify from 'rollup-plugin-uglify'
 import filesize from 'rollup-plugin-filesize'
 
+const externalModules = ['ramda', 'axios']
+
+function isImportExternal (importStr) {
+  let external = false
+
+  // Check for each of the external modules defined above
+  externalModules.forEach(externalModule => {
+    if (importStr.indexOf(externalModule) >= 0) external = true
+  })
+
+  return external
+}
+
 export default {
   entry: 'lib/apisauce.js',
   format: 'cjs',
@@ -9,12 +22,12 @@ export default {
     babel({
       babelrc: false,
       presets: ['es2015-rollup'],
-      plugins: ['fast-async', 'transform-object-rest-spread']
+      plugins: ['fast-async', 'transform-object-rest-spread', 'ramda']
     }),
     uglify(),
     filesize()
   ],
   exports: 'named',
   dest: 'dist/apisauce.js',
-  external: ['ramda', 'axios']
+  external: isImportExternal
 }


### PR DESCRIPTION
This makes it so browser applications using this library don't bundle the entire ramda library in their production builds. Reduced our gziped build size by 40kb!