### PR TITLE
Starts the conversion to TypeScript.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,6 @@
 {
   "presets": [ "es2015" ],
-  "plugins": [
-    "fast-async",
-    "transform-object-rest-spread",
-    "ramda"
-  ],
+  "plugins": [ "ramda" ],
   "ignore": "test/*",
   "env": {
     "development": {

--- a/lib/apisauce.js
+++ b/lib/apisauce.js
@@ -1,31 +1,49 @@
-import axios from 'axios'
-import {
-  cond,
-  isNil,
-  identity,
-  is,
-  T,
-  curry,
-  gte,
-  anyPass,
-  isEmpty,
-  ifElse,
-  complement,
-  has,
-  prop,
-  propIs,
-  propSatisfies,
-  merge,
-  dissoc,
-  keys,
-  forEach,
-  pipe,
-  partial,
-  contains,
-  always,
-  __
-} from 'ramda'
-
+var __assign = (this && this.__assign) || Object.assign || function(t) {
+    for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+            t[p] = s[p];
+    }
+    return t;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var _this = this;
+import axios from 'axios';
+import { cond, isNil, identity, is, T, curry, gte, anyPass, isEmpty, ifElse, complement, has, prop, propIs, propSatisfies, merge, dissoc, keys, forEach, pipe, partial, contains, always } from 'ramda';
 /**
  * Converts the parameter to a number.
  *
@@ -38,12 +56,11 @@ import {
  * @example
  * toNumber('7') //=> 7
  */
-const toNumber = cond([
-  [isNil, identity],
-  [is(Number), identity],
-  [T, x => Number(x)]
-])
-
+var toNumber = cond([
+    [isNil, identity],
+    [is(Number), identity],
+    [T, function (x) { return Number(x); }]
+]);
 /**
  * Given a min and max, determines if the value is included
  * in the range.
@@ -61,300 +78,287 @@ const toNumber = cond([
  * isWithin(1, 5, 5) //=> true
  * isWithin(1, 5, 5.1) //=> false
  */
-const isWithin = curry((min, max, value) => {
-  const isNumber = is(Number)
-  return (
-    isNumber(min) &&
-    isNumber(max) &&
-    isNumber(value) &&
-    gte(value, min) &&
-    gte(max, value)
-  )
-})
-
+var isWithin = curry(function (min, max, value) {
+    var isNumber = is(Number);
+    return (isNumber(min) &&
+        isNumber(max) &&
+        isNumber(value) &&
+        gte(value, min) &&
+        gte(max, value));
+});
+// a workaround to deal with __ not being available from the ramda types in typescript
+var containsText = function (textToSearch) { return function (list) { return contains(list, textToSearch); }; };
 // check for an invalid config
-const isInvalidConfig = anyPass([
-  isNil,
-  isEmpty,
-  complement(has('baseURL')),
-  complement(propIs(String, 'baseURL')),
-  propSatisfies(isEmpty, 'baseURL')
-])
-
+var isInvalidConfig = anyPass([
+    isNil,
+    isEmpty,
+    complement(has('baseURL')),
+    complement(propIs(String, 'baseURL')),
+    propSatisfies(isEmpty, 'baseURL')
+]);
 /**
  * Are we dealing with a promise?
  */
-const isPromise = obj =>
-  !!obj &&
-  (typeof obj === 'object' || typeof obj === 'function') &&
-  typeof obj.then === 'function'
-
+var isPromise = function (obj) {
+    return !!obj &&
+        (typeof obj === 'object' || typeof obj === 'function') &&
+        typeof obj.then === 'function';
+};
 // the default headers given to axios
-export const DEFAULT_HEADERS = {
-  Accept: 'application/json',
-  'Content-Type': 'application/json'
-}
-
+export var DEFAULT_HEADERS = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json'
+};
 // the default configuration for axios, default headers will also be merged in
-const DEFAULT_CONFIG = {
-  timeout: 0
-}
-
-export const NONE = null
-export const CLIENT_ERROR = 'CLIENT_ERROR'
-export const SERVER_ERROR = 'SERVER_ERROR'
-export const TIMEOUT_ERROR = 'TIMEOUT_ERROR'
-export const CONNECTION_ERROR = 'CONNECTION_ERROR'
-export const NETWORK_ERROR = 'NETWORK_ERROR'
-export const UNKNOWN_ERROR = 'UNKNOWN_ERROR'
-export const CANCEL_ERROR = 'CANCEL_ERROR'
-
-const TIMEOUT_ERROR_CODES = ['ECONNABORTED']
-const NODEJS_CONNECTION_ERROR_CODES = [
-  'ENOTFOUND',
-  'ECONNREFUSED',
-  'ECONNRESET'
-]
-const in200s = isWithin(200, 299)
-const in400s = isWithin(400, 499)
-const in500s = isWithin(500, 599)
-const statusNil = ifElse(isNil, always(undefined), prop('status'))
+var DEFAULT_CONFIG = {
+    timeout: 0
+};
+export var NONE = null;
+export var CLIENT_ERROR = 'CLIENT_ERROR';
+export var SERVER_ERROR = 'SERVER_ERROR';
+export var TIMEOUT_ERROR = 'TIMEOUT_ERROR';
+export var CONNECTION_ERROR = 'CONNECTION_ERROR';
+export var NETWORK_ERROR = 'NETWORK_ERROR';
+export var UNKNOWN_ERROR = 'UNKNOWN_ERROR';
+export var CANCEL_ERROR = 'CANCEL_ERROR';
+var TIMEOUT_ERROR_CODES = ['ECONNABORTED'];
+var NODEJS_CONNECTION_ERROR_CODES = [
+    'ENOTFOUND',
+    'ECONNREFUSED',
+    'ECONNRESET'
+];
+var in200s = isWithin(200, 299);
+var in400s = isWithin(400, 499);
+var in500s = isWithin(500, 599);
+var statusNil = ifElse(isNil, always(undefined), prop('status'));
 /**
   Creates a instance of our API using the configuration.
  */
-export const create = config => {
-  // quick sanity check
-  if (isInvalidConfig(config)) throw new Error('config must have a baseURL')
-
-  // combine the user's defaults with ours
-  const headers = merge(DEFAULT_HEADERS, config.headers || {})
-  const combinedConfig = merge(DEFAULT_CONFIG, dissoc('headers', config))
-
-  // create the axios instance
-  const instance = axios.create(combinedConfig)
-
-  const monitors = []
-  const addMonitor = monitor => {
-    monitors.push(monitor)
-  }
-
-  const requestTransforms = []
-  const asyncRequestTransforms = []
-  const responseTransforms = []
-
-  const addRequestTransform = transform => requestTransforms.push(transform)
-  const addAsyncRequestTransform = transform =>
-    asyncRequestTransforms.push(transform)
-  const addResponseTransform = transform => responseTransforms.push(transform)
-
-  // convenience for setting new request headers
-  const setHeader = (name, value) => {
-    headers[name] = value
-    return instance
-  }
-
-  // sets headers in bulk
-  const setHeaders = headers => {
-    forEach(header => setHeader(header, headers[header]), keys(headers))
-    return instance
-  }
-
-  // remove header
-  const deleteHeader = name => {
-    delete headers[name]
-    return instance
-  }
-
-  /**
-   * Sets a new base URL.
-   */
-  const setBaseURL = newURL => {
-    instance.defaults.baseURL = newURL
-    return instance
-  }
-
-  /**
-   * Gets the current base URL used by axios.
-   */
-  const getBaseURL = () => {
-    return instance.defaults.baseURL
-  }
-
-  /**
-    Make the request for GET, HEAD, DELETE
-   */
-  const doRequestWithoutBody = (method, url, params = {}, axiosConfig = {}) => {
-    return doRequest(merge({ url, params, method }, axiosConfig))
-  }
-
-  /**
-    Make the request for POST, PUT, PATCH
-   */
-  const doRequestWithBody = (method, url, data = null, axiosConfig = {}) => {
-    return doRequest(merge({ url, method, data }, axiosConfig))
-  }
-
-  /**
-    Make the request with this config!
-   */
-  const doRequest = async axiosRequestConfig => {
-    axiosRequestConfig.headers = {
-      ...headers,
-      ...axiosRequestConfig.headers
-    }
-
-    // add the request transforms
-    if (requestTransforms.length > 0) {
-      // overwrite our axios request with whatever our object looks like now
-      // axiosRequestConfig = doRequestTransforms(requestTransforms, axiosRequestConfig)
-      forEach(transform => transform(axiosRequestConfig), requestTransforms)
-    }
-
-    // add the async request transforms
-    if (asyncRequestTransforms.length > 0) {
-      for (let index = 0; index < asyncRequestTransforms.length; index++) {
-        const transform = asyncRequestTransforms[index](axiosRequestConfig)
-        if (isPromise(transform)) {
-          await transform
-        } else {
-          await transform(axiosRequestConfig)
+export var create = function (config) {
+    // quick sanity check
+    if (isInvalidConfig(config))
+        throw new Error('config must have a baseURL');
+    // combine the user's defaults with ours
+    var headers = merge(DEFAULT_HEADERS, config.headers || {});
+    var combinedConfig = merge(DEFAULT_CONFIG, dissoc('headers', config));
+    // create the axios instance
+    var instance = axios.create(combinedConfig);
+    var monitors = [];
+    var addMonitor = function (monitor) {
+        monitors.push(monitor);
+    };
+    var requestTransforms = [];
+    var asyncRequestTransforms = [];
+    var responseTransforms = [];
+    var addRequestTransform = function (transform) { return requestTransforms.push(transform); };
+    var addAsyncRequestTransform = function (transform) {
+        return asyncRequestTransforms.push(transform);
+    };
+    var addResponseTransform = function (transform) { return responseTransforms.push(transform); };
+    // convenience for setting new request headers
+    var setHeader = function (name, value) {
+        headers[name] = value;
+        return instance;
+    };
+    // sets headers in bulk
+    var setHeaders = function (headers) {
+        forEach(function (header) { return setHeader(header, headers[header]); }, keys(headers));
+        return instance;
+    };
+    // remove header
+    var deleteHeader = function (name) {
+        delete headers[name];
+        return instance;
+    };
+    /**
+     * Sets a new base URL.
+     */
+    var setBaseURL = function (newURL) {
+        instance.defaults.baseURL = newURL;
+        return instance;
+    };
+    /**
+     * Gets the current base URL used by axios.
+     */
+    var getBaseURL = function () {
+        return instance.defaults.baseURL;
+    };
+    /**
+      Make the request for GET, HEAD, DELETE
+     */
+    var doRequestWithoutBody = function (method, url, params, axiosConfig) {
+        if (params === void 0) { params = {}; }
+        if (axiosConfig === void 0) { axiosConfig = {}; }
+        return doRequest(merge({ url: url, params: params, method: method }, axiosConfig));
+    };
+    /**
+      Make the request for POST, PUT, PATCH
+     */
+    var doRequestWithBody = function (method, url, data, axiosConfig) {
+        if (data === void 0) { data = null; }
+        if (axiosConfig === void 0) { axiosConfig = {}; }
+        return doRequest(merge({ url: url, method: method, data: data }, axiosConfig));
+    };
+    /**
+      Make the request with this config!
+     */
+    var doRequest = function (axiosRequestConfig) { return __awaiter(_this, void 0, void 0, function () {
+        var index, transform, chain;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    axiosRequestConfig.headers = __assign({}, headers, axiosRequestConfig.headers);
+                    // add the request transforms
+                    if (requestTransforms.length > 0) {
+                        // overwrite our axios request with whatever our object looks like now
+                        // axiosRequestConfig = doRequestTransforms(requestTransforms, axiosRequestConfig)
+                        forEach(function (transform) { return transform(axiosRequestConfig); }, requestTransforms);
+                    }
+                    if (!(asyncRequestTransforms.length > 0)) return [3 /*break*/, 6];
+                    index = 0;
+                    _a.label = 1;
+                case 1:
+                    if (!(index < asyncRequestTransforms.length)) return [3 /*break*/, 6];
+                    transform = asyncRequestTransforms[index](axiosRequestConfig);
+                    if (!isPromise(transform)) return [3 /*break*/, 3];
+                    return [4 /*yield*/, transform];
+                case 2:
+                    _a.sent();
+                    return [3 /*break*/, 5];
+                case 3: return [4 /*yield*/, transform(axiosRequestConfig)];
+                case 4:
+                    _a.sent();
+                    _a.label = 5;
+                case 5:
+                    index++;
+                    return [3 /*break*/, 1];
+                case 6:
+                    chain = pipe(convertResponse(toNumber(new Date())), 
+                    // partial(convertResponse, [toNumber(new Date())]),
+                    runMonitors);
+                    return [2 /*return*/, instance.request(axiosRequestConfig).then(chain).catch(chain)];
+            }
+        });
+    }); };
+    /**
+      Fires after we convert from axios' response into our response.  Exceptions
+      raised for each monitor will be ignored.
+     */
+    var runMonitors = function (ourResponse) {
+        monitors.forEach(function (monitor) {
+            try {
+                monitor(ourResponse);
+            }
+            catch (error) {
+                // all monitor complaints will be ignored
+            }
+        });
+        return ourResponse;
+    };
+    /**
+      Converts an axios response/error into our response.
+     */
+    var convertResponse = curry(function (startedAt, axiosResult) {
+        var end = toNumber(new Date());
+        var duration = end - startedAt;
+        // new in Axios 0.13 -- some data could be buried 1 level now
+        var isError = axiosResult instanceof Error || axios.isCancel(axiosResult);
+        var axiosResponse = axiosResult;
+        var axiosError = axiosResult;
+        var response = isError ? axiosError.response : axiosResponse;
+        var status = (response && response.status) || null;
+        var problem = isError
+            ? getProblemFromError(axiosResult)
+            : getProblemFromStatus(status);
+        var ok = in200s(status);
+        var config = axiosResult.config || null;
+        var headers = (response && response.headers) || null;
+        var data = (response && response.data) || null;
+        // give an opportunity for anything to the response transforms to change stuff along the way
+        var transformedResponse = {
+            duration: duration,
+            problem: problem,
+            ok: ok,
+            status: status,
+            headers: headers,
+            config: config,
+            data: data
+        };
+        if (responseTransforms.length > 0) {
+            forEach(function (transform) { return transform(transformedResponse); }, responseTransforms);
         }
-      }
-    }
-
-    // after the call, convert the axios response, then execute our monitors
-    const chain = pipe(
-      partial(convertResponse, [toNumber(new Date())]),
-      runMonitors
-    )
-
-    return instance.request(axiosRequestConfig).then(chain).catch(chain)
-  }
-
-  /**
-    Fires after we convert from axios' response into our response.  Exceptions
-    raised for each monitor will be ignored.
-   */
-  const runMonitors = ourResponse => {
-    monitors.forEach(monitor => {
-      try {
-        monitor(ourResponse)
-      } catch (error) {
-        // all monitor complaints will be ignored
-      }
-    })
-    return ourResponse
-  }
-
-  /**
-    Converts an axios response/error into our response.
-   */
-  const convertResponse = (startedAt, axiosResponse) => {
-    const end = toNumber(new Date())
-    const duration = end - startedAt
-
-    // new in Axios 0.13 -- some data could be buried 1 level now
-    const isError =
-      axiosResponse instanceof Error || axios.isCancel(axiosResponse)
-    const response = isError ? axiosResponse.response : axiosResponse
-    const status = (response && response.status) || null
-    const problem = isError
-      ? getProblemFromError(axiosResponse)
-      : getProblemFromStatus(status)
-    const ok = in200s(status)
-    const config = axiosResponse.config || null
-    const headers = (response && response.headers) || null
-    let data = (response && response.data) || null
-
-    // give an opportunity for anything to the response transforms to change stuff along the way
-    let transformedResponse = {
-      duration,
-      problem,
-      ok,
-      status,
-      headers,
-      config,
-      data
-    }
-    if (responseTransforms.length > 0) {
-      forEach(transform => transform(transformedResponse), responseTransforms)
-    }
-
-    return transformedResponse
-  }
-
-  /**
-    What's the problem for this response?
-
-    TODO: We're losing some error granularity, but i'm cool with that
-    until someone cares.
-   */
-  const getProblemFromError = error => {
-    // first check if the error message is Network Error (set by axios at 0.12) on platforms other than NodeJS.
-    if (error.message === 'Network Error') return NETWORK_ERROR
-    if (axios.isCancel(error)) return CANCEL_ERROR
-
-    // then check the specific error code
-    return cond([
-      // if we don't have an error code, we have a response status
-      [isNil, () => getProblemFromStatus(statusNil(error.response))],
-      [contains(__, TIMEOUT_ERROR_CODES), always(TIMEOUT_ERROR)],
-      [contains(__, NODEJS_CONNECTION_ERROR_CODES), always(CONNECTION_ERROR)],
-      [T, always(UNKNOWN_ERROR)]
-    ])(error.code)
-  }
-
-  /**
-   * Given a HTTP status code, return back the appropriate problem enum.
-   */
-  const getProblemFromStatus = status => {
-    return cond([
-      [isNil, always(UNKNOWN_ERROR)],
-      [in200s, always(NONE)],
-      [in400s, always(CLIENT_ERROR)],
-      [in500s, always(SERVER_ERROR)],
-      [T, always(UNKNOWN_ERROR)]
-    ])(status)
-  }
-
-  // create the base object
-  const sauce = {
-    axiosInstance: instance,
-    monitors,
-    addMonitor,
-    requestTransforms,
-    asyncRequestTransforms,
-    responseTransforms,
-    addRequestTransform,
-    addAsyncRequestTransform,
-    addResponseTransform,
-    setHeader,
-    setHeaders,
-    deleteHeader,
-    headers,
-    setBaseURL,
-    getBaseURL,
-    get: partial(doRequestWithoutBody, ['get']),
-    delete: partial(doRequestWithoutBody, ['delete']),
-    head: partial(doRequestWithoutBody, ['head']),
-    post: partial(doRequestWithBody, ['post']),
-    put: partial(doRequestWithBody, ['put']),
-    patch: partial(doRequestWithBody, ['patch']),
-    link: partial(doRequestWithoutBody, ['link']),
-    unlink: partial(doRequestWithoutBody, ['unlink'])
-  }
-  // send back the sauce
-  return sauce
-}
-
+        return transformedResponse;
+    });
+    /**
+      What's the problem for this response?
+  
+      TODO: We're losing some error granularity, but i'm cool with that
+      until someone cares.
+     */
+    var getProblemFromError = function (error) {
+        // first check if the error message is Network Error (set by axios at 0.12) on platforms other than NodeJS.
+        if (error.message === 'Network Error')
+            return NETWORK_ERROR;
+        if (axios.isCancel(error))
+            return CANCEL_ERROR;
+        // then check the specific error code
+        return cond([
+            // if we don't have an error code, we have a response status
+            [isNil, function () { return getProblemFromStatus(statusNil(error.response)); }],
+            [containsText(TIMEOUT_ERROR_CODES), always(TIMEOUT_ERROR)],
+            [containsText(NODEJS_CONNECTION_ERROR_CODES), always(CONNECTION_ERROR)],
+            [T, always(UNKNOWN_ERROR)]
+        ])(error.code);
+    };
+    /**
+     * Given a HTTP status code, return back the appropriate problem enum.
+     */
+    var getProblemFromStatus = function (status) {
+        return cond([
+            [isNil, always(UNKNOWN_ERROR)],
+            [in200s, always(NONE)],
+            [in400s, always(CLIENT_ERROR)],
+            [in500s, always(SERVER_ERROR)],
+            [T, always(UNKNOWN_ERROR)]
+        ])(status);
+    };
+    // create the base object
+    var sauce = {
+        axiosInstance: instance,
+        monitors: monitors,
+        addMonitor: addMonitor,
+        requestTransforms: requestTransforms,
+        asyncRequestTransforms: asyncRequestTransforms,
+        responseTransforms: responseTransforms,
+        addRequestTransform: addRequestTransform,
+        addAsyncRequestTransform: addAsyncRequestTransform,
+        addResponseTransform: addResponseTransform,
+        setHeader: setHeader,
+        setHeaders: setHeaders,
+        deleteHeader: deleteHeader,
+        headers: headers,
+        setBaseURL: setBaseURL,
+        getBaseURL: getBaseURL,
+        get: partial(doRequestWithoutBody, ['get']),
+        delete: partial(doRequestWithoutBody, ['delete']),
+        head: partial(doRequestWithoutBody, ['head']),
+        post: partial(doRequestWithBody, ['post']),
+        put: partial(doRequestWithBody, ['put']),
+        patch: partial(doRequestWithBody, ['patch']),
+        link: partial(doRequestWithoutBody, ['link']),
+        unlink: partial(doRequestWithoutBody, ['unlink'])
+    };
+    // send back the sauce
+    return sauce;
+};
 export default {
-  DEFAULT_HEADERS,
-  NONE,
-  CLIENT_ERROR,
-  SERVER_ERROR,
-  TIMEOUT_ERROR,
-  CONNECTION_ERROR,
-  NETWORK_ERROR,
-  UNKNOWN_ERROR,
-  create
-}
+    DEFAULT_HEADERS: DEFAULT_HEADERS,
+    NONE: NONE,
+    CLIENT_ERROR: CLIENT_ERROR,
+    SERVER_ERROR: SERVER_ERROR,
+    TIMEOUT_ERROR: TIMEOUT_ERROR,
+    CONNECTION_ERROR: CONNECTION_ERROR,
+    NETWORK_ERROR: NETWORK_ERROR,
+    UNKNOWN_ERROR: UNKNOWN_ERROR,
+    create: create
+};

--- a/lib/apisauce.ts
+++ b/lib/apisauce.ts
@@ -1,0 +1,365 @@
+import axios from 'axios'
+import { AxiosResponse, AxiosError } from 'axios'
+import {
+  cond,
+  isNil,
+  identity,
+  is,
+  T,
+  curry,
+  gte,
+  anyPass,
+  isEmpty,
+  ifElse,
+  complement,
+  has,
+  prop,
+  propIs,
+  propSatisfies,
+  merge,
+  dissoc,
+  keys,
+  forEach,
+  pipe,
+  partial,
+  contains,
+  always
+} from 'ramda'
+
+/**
+ * Converts the parameter to a number.
+ *
+ * Number, null, and undefined will return themselves,
+ * but everything else will be convert to a Number, or
+ * die trying.
+ *
+ * @param {String} the String to convert
+ * @return {Number} the Number version
+ * @example
+ * toNumber('7') //=> 7
+ */
+const toNumber = cond([
+  [isNil, identity],
+  [is(Number), identity],
+  [T, x => Number(x)]
+])
+
+/**
+ * Given a min and max, determines if the value is included
+ * in the range.
+ *
+ * This function is curried.
+ *
+ * @sig Number a -> a -> a -> b
+ * @param {Number} the minimum number
+ * @param {Number} the maximum number
+ * @param {Number} the value to test
+ * @return {Boolean} is the value in the range?
+ * @example
+ * isWithin(1, 5, 3) //=> true
+ * isWithin(1, 5, 1) //=> true
+ * isWithin(1, 5, 5) //=> true
+ * isWithin(1, 5, 5.1) //=> false
+ */
+const isWithin = curry((min, max, value) => {
+  const isNumber = is(Number)
+  return (
+    isNumber(min) &&
+    isNumber(max) &&
+    isNumber(value) &&
+    gte(value, min) &&
+    gte(max, value)
+  )
+})
+
+// a workaround to deal with __ not being available from the ramda types in typescript
+const containsText = textToSearch => list => contains(list, textToSearch)
+
+// check for an invalid config
+const isInvalidConfig = anyPass([
+  isNil,
+  isEmpty,
+  complement(has('baseURL')),
+  complement(propIs(String, 'baseURL')),
+  propSatisfies(isEmpty, 'baseURL')
+])
+
+/**
+ * Are we dealing with a promise?
+ */
+const isPromise = obj =>
+  !!obj &&
+  (typeof obj === 'object' || typeof obj === 'function') &&
+  typeof obj.then === 'function'
+
+// the default headers given to axios
+export const DEFAULT_HEADERS = {
+  Accept: 'application/json',
+  'Content-Type': 'application/json'
+}
+
+// the default configuration for axios, default headers will also be merged in
+const DEFAULT_CONFIG = {
+  timeout: 0
+}
+
+export const NONE = null
+export const CLIENT_ERROR = 'CLIENT_ERROR'
+export const SERVER_ERROR = 'SERVER_ERROR'
+export const TIMEOUT_ERROR = 'TIMEOUT_ERROR'
+export const CONNECTION_ERROR = 'CONNECTION_ERROR'
+export const NETWORK_ERROR = 'NETWORK_ERROR'
+export const UNKNOWN_ERROR = 'UNKNOWN_ERROR'
+export const CANCEL_ERROR = 'CANCEL_ERROR'
+
+const TIMEOUT_ERROR_CODES = ['ECONNABORTED']
+const NODEJS_CONNECTION_ERROR_CODES = [
+  'ENOTFOUND',
+  'ECONNREFUSED',
+  'ECONNRESET'
+]
+const in200s = isWithin(200, 299)
+const in400s = isWithin(400, 499)
+const in500s = isWithin(500, 599)
+const statusNil = ifElse(isNil, always(undefined), prop('status'))
+/**
+  Creates a instance of our API using the configuration.
+ */
+export const create = config => {
+  // quick sanity check
+  if (isInvalidConfig(config)) throw new Error('config must have a baseURL')
+
+  // combine the user's defaults with ours
+  const headers = merge(DEFAULT_HEADERS, config.headers || {})
+  const combinedConfig = merge(DEFAULT_CONFIG, dissoc('headers', config))
+
+  // create the axios instance
+  const instance = axios.create(combinedConfig)
+
+  const monitors = []
+  const addMonitor = monitor => {
+    monitors.push(monitor)
+  }
+
+  const requestTransforms = []
+  const asyncRequestTransforms = []
+  const responseTransforms = []
+
+  const addRequestTransform = transform => requestTransforms.push(transform)
+  const addAsyncRequestTransform = transform =>
+    asyncRequestTransforms.push(transform)
+  const addResponseTransform = transform => responseTransforms.push(transform)
+
+  // convenience for setting new request headers
+  const setHeader = (name, value) => {
+    headers[name] = value
+    return instance
+  }
+
+  // sets headers in bulk
+  const setHeaders = headers => {
+    forEach(header => setHeader(header, headers[header]), keys(headers))
+    return instance
+  }
+
+  // remove header
+  const deleteHeader = name => {
+    delete headers[name]
+    return instance
+  }
+
+  /**
+   * Sets a new base URL.
+   */
+  const setBaseURL = newURL => {
+    instance.defaults.baseURL = newURL
+    return instance
+  }
+
+  /**
+   * Gets the current base URL used by axios.
+   */
+  const getBaseURL = () => {
+    return instance.defaults.baseURL
+  }
+
+  /**
+    Make the request for GET, HEAD, DELETE
+   */
+  const doRequestWithoutBody = (method, url, params = {}, axiosConfig = {}) => {
+    return doRequest(merge({ url, params, method }, axiosConfig))
+  }
+
+  /**
+    Make the request for POST, PUT, PATCH
+   */
+  const doRequestWithBody = (method, url, data = null, axiosConfig = {}) => {
+    return doRequest(merge({ url, method, data }, axiosConfig))
+  }
+
+  /**
+    Make the request with this config!
+   */
+  const doRequest = async axiosRequestConfig => {
+    axiosRequestConfig.headers = {
+      ...headers,
+      ...axiosRequestConfig.headers
+    }
+
+    // add the request transforms
+    if (requestTransforms.length > 0) {
+      // overwrite our axios request with whatever our object looks like now
+      // axiosRequestConfig = doRequestTransforms(requestTransforms, axiosRequestConfig)
+      forEach(transform => transform(axiosRequestConfig), requestTransforms)
+    }
+
+    // add the async request transforms
+    if (asyncRequestTransforms.length > 0) {
+      for (let index = 0; index < asyncRequestTransforms.length; index++) {
+        const transform = asyncRequestTransforms[index](axiosRequestConfig)
+        if (isPromise(transform)) {
+          await transform
+        } else {
+          await transform(axiosRequestConfig)
+        }
+      }
+    }
+
+    // after the call, convert the axios response, then execute our monitors
+    const chain = pipe(
+      convertResponse(toNumber(new Date())),
+      // partial(convertResponse, [toNumber(new Date())]),
+      runMonitors
+    )
+
+    return instance.request(axiosRequestConfig).then(chain).catch(chain)
+  }
+
+  /**
+    Fires after we convert from axios' response into our response.  Exceptions
+    raised for each monitor will be ignored.
+   */
+  const runMonitors = ourResponse => {
+    monitors.forEach(monitor => {
+      try {
+        monitor(ourResponse)
+      } catch (error) {
+        // all monitor complaints will be ignored
+      }
+    })
+    return ourResponse
+  }
+
+  /**
+    Converts an axios response/error into our response.
+   */
+  const convertResponse = curry((startedAt: number, axiosResult: AxiosResponse | AxiosError) => {
+    const end: number = toNumber(new Date())
+    const duration: number = end - startedAt
+
+    // new in Axios 0.13 -- some data could be buried 1 level now
+    const isError = axiosResult instanceof Error || axios.isCancel(axiosResult)
+    const axiosResponse = axiosResult as AxiosResponse
+    const axiosError = axiosResult as AxiosError
+    const response = isError ? axiosError.response : axiosResponse
+    const status = (response && response.status) || null
+    const problem = isError
+      ? getProblemFromError(axiosResult)
+      : getProblemFromStatus(status)
+    const ok = in200s(status)
+    const config = axiosResult.config || null
+    const headers = (response && response.headers) || null
+    let data = (response && response.data) || null
+
+    // give an opportunity for anything to the response transforms to change stuff along the way
+    let transformedResponse = {
+      duration,
+      problem,
+      ok,
+      status,
+      headers,
+      config,
+      data
+    }
+    if (responseTransforms.length > 0) {
+      forEach(transform => transform(transformedResponse), responseTransforms)
+    }
+
+    return transformedResponse
+  })
+
+  /**
+    What's the problem for this response?
+
+    TODO: We're losing some error granularity, but i'm cool with that
+    until someone cares.
+   */
+  const getProblemFromError = error => {
+    // first check if the error message is Network Error (set by axios at 0.12) on platforms other than NodeJS.
+    if (error.message === 'Network Error') return NETWORK_ERROR
+    if (axios.isCancel(error)) return CANCEL_ERROR
+
+    // then check the specific error code
+    return cond([
+      // if we don't have an error code, we have a response status
+      [isNil, () => getProblemFromStatus(statusNil(error.response))],
+      [containsText(TIMEOUT_ERROR_CODES), always(TIMEOUT_ERROR)],
+      [containsText(NODEJS_CONNECTION_ERROR_CODES), always(CONNECTION_ERROR)],
+      [T, always(UNKNOWN_ERROR)]
+    ])(error.code)
+  }
+
+  /**
+   * Given a HTTP status code, return back the appropriate problem enum.
+   */
+  const getProblemFromStatus = status => {
+    return cond([
+      [isNil, always(UNKNOWN_ERROR)],
+      [in200s, always(NONE)],
+      [in400s, always(CLIENT_ERROR)],
+      [in500s, always(SERVER_ERROR)],
+      [T, always(UNKNOWN_ERROR)]
+    ])(status)
+  }
+
+  // create the base object
+  const sauce = {
+    axiosInstance: instance,
+    monitors,
+    addMonitor,
+    requestTransforms,
+    asyncRequestTransforms,
+    responseTransforms,
+    addRequestTransform,
+    addAsyncRequestTransform,
+    addResponseTransform,
+    setHeader,
+    setHeaders,
+    deleteHeader,
+    headers,
+    setBaseURL,
+    getBaseURL,
+    get: partial(doRequestWithoutBody, ['get']),
+    delete: partial(doRequestWithoutBody, ['delete']),
+    head: partial(doRequestWithoutBody, ['head']),
+    post: partial(doRequestWithBody, ['post']),
+    put: partial(doRequestWithBody, ['put']),
+    patch: partial(doRequestWithBody, ['patch']),
+    link: partial(doRequestWithoutBody, ['link']),
+    unlink: partial(doRequestWithoutBody, ['unlink'])
+  }
+  // send back the sauce
+  return sauce
+}
+
+export default {
+  DEFAULT_HEADERS,
+  NONE,
+  CLIENT_ERROR,
+  SERVER_ERROR,
+  TIMEOUT_ERROR,
+  CONNECTION_ERROR,
+  NETWORK_ERROR,
+  UNKNOWN_ERROR,
+  create
+}

--- a/package.json
+++ b/package.json
@@ -1,64 +1,66 @@
 {
-  "name": "apisauce",
-  "version": "0.13.0",
+  "author": "Steve Kellock <steve@kellock.ca>",
+  "ava": {
+    "require": [
+      "babel-core/register"
+    ]
+  },
+  "dependencies": {
+    "axios": "^0.16.2",
+    "ramda": "^0.24.1"
+  },
   "description": "Axios + standardized errors + request/response transforms.",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/skellock/apisauce.git"
+  "devDependencies": {
+    "@types/ramda": "^0.0.15",
+    "ava": "^0.19.1",
+    "babel-cli": "^6.24.1",
+    "babel-core": "^6.25.0",
+    "babel-eslint": "^7.2.3",
+    "babel-plugin-ramda": "^1.2.0",
+    "babel-preset-es2015": "^6.24.1",
+    "np": "^2.16.0",
+    "npm-run-all": "^4.0.2",
+    "nyc": "^11.0.2",
+    "ramdasauce": "^2.0.0",
+    "rollup": "^0.43.0",
+    "rollup-plugin-babel": "^2.7.1",
+    "rollup-plugin-filesize": "^1.3.2",
+    "rollup-plugin-uglify": "^2.0.1",
+    "standard": "^10.0.2",
+    "typescript": "^2.3.4"
   },
-  "main": "./dist/apisauce.js",
-  "types": "./dist/apisauce.d.ts",
-  "scripts": {
-    "test": "ava -s",
-    "coverage": "nyc ava",
-    "dist": "npm run clean && npm run build && npm run types",
-    "types": "cp lib/apisauce.d.ts dist/",
-    "clean": "rm -rf dist",
-    "build": "BABEL_ENV=production rollup -c",
-    "lint": "standard lib/* test/* rollup.config.js",
-    "shipit": "npm run dist && np"
-  },
+  "files": [
+    "dist/apisauce.js",
+    "dist/apisauce.d.ts"
+  ],
   "keywords": [
     "axios",
     "api",
     "network",
     "http"
   ],
-  "author": "Steve Kellock <steve@kellock.ca>",
   "license": "MIT",
-  "files": [
-    "dist/apisauce.js",
-    "dist/apisauce.d.ts"
-  ],
-  "dependencies": {
-    "axios": "^0.16.1",
-    "ramda": "^0.23.0"
+  "main": "./dist/apisauce.js",
+  "name": "apisauce",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/skellock/apisauce.git"
   },
-  "devDependencies": {
-    "ava": "^0.19.1",
-    "babel-cli": "^6.24.1",
-    "babel-core": "^6.24.1",
-    "babel-eslint": "^7.2.2",
-    "babel-plugin-ramda": "^1.2.0",
-    "babel-plugin-transform-object-rest-spread": "^6.23.0",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-es2015-rollup": "^3.0.0",
-    "fast-async": "^6.2.2",
-    "np": "^2.13.2",
-    "nyc": "^10.2.0",
-    "ramdasauce": "^1.2.0",
-    "rollup": "^0.41.6",
-    "rollup-plugin-babel": "^2.7.1",
-    "rollup-plugin-filesize": "^1.2.1",
-    "rollup-plugin-uglify": "^1.0.2",
-    "standard": "^10.0.2"
-  },
-  "ava": {
-    "require": [
-      "babel-core/register"
-    ]
+  "scripts": {
+    "build": "BABEL_ENV=production rollup -c",
+    "clean": "rm -rf dist",
+    "compile": "tsc -p tsconfig.json",
+    "coverage": "nyc ava",
+    "dist": "npm-run-all clean compile build types",
+    "lint": "standard lib/* test/* rollup.config.js",
+    "shipit": "npm-run-all dist np",
+    "test": "npm-run-all compile test:unit",
+    "test:unit": "ava -s",
+    "types": "cp lib/apisauce.d.ts dist/"
   },
   "standard": {
     "parser": "babel-eslint"
-  }
+  },
+  "types": "./dist/apisauce.d.ts",
+  "version": "0.13.0"
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,11 +19,7 @@ export default {
   entry: 'lib/apisauce.js',
   format: 'cjs',
   plugins: [
-    babel({
-      babelrc: false,
-      presets: ['es2015-rollup'],
-      plugins: ['fast-async', 'transform-object-rest-spread', 'ramda']
-    }),
+    babel({ babelrc: false, plugins: ['ramda'] }),
     uglify(),
     filesize()
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "target": "es5",
+    "module": "es2015",
+    "strict": false,
+    "lib": ["es2015"]
+  },
+  "include": [
+    "lib"
+  ]
+}


### PR DESCRIPTION
This just gets us up and running with TypeScript.  `fast-async` was causing some issues with the latest React Native.  I didn't realize it was doing hacky stuff, so I'm ejecting.

I'll sweep through the library and rebuild it with TypeScript first-class, but this solves the immediate problem.

This works well on React Native 0.45.1 and the latest `create-react-app`.

Addresses #108.

